### PR TITLE
Add AGS integration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,11 @@ hideBrowseMediaButton: true # default is false. Hides the button to open the med
 replaceHttpWithHttpsForThumbnails: true # default is false. Use this if you  want to replace http with https for thumbnails. 
 mediaBrowserTitle: My favorites # default is 'All favorites'. Use this to change the title for the media browser/favorites section.
 sortFavoritesByType: true # default is false. Will group favorites by type (e.g. radio, playlist, album).
+agsPrimarySpeakerSensor: sensor.ags_primary_speaker
+agsPreferredPrimarySensor: sensor.ags_preferred_primary
+agsStatusSensor: sensor.ags_status
+agsSystemSwitch: switch.media_system
+agsRoomSwitchPrefix: switch.media_room_
 
 # volumes specific
 hideVolumeCogwheel: true # default is false. Will hide the cogwheel for the volumes section.

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,11 @@ export interface CardConfig extends LovelaceCardConfig {
   stopInsteadOfPause?: boolean;
   inverseGroupMuteState?: boolean;
   sortFavoritesByType?: boolean;
+  agsPrimarySpeakerSensor?: string; // sensor.ags_primary_speaker
+  agsPreferredPrimarySensor?: string; // sensor.ags_preferred_primary
+  agsStatusSensor?: string; // sensor.ags_status
+  agsSystemSwitch?: string; // switch.media_system
+  agsRoomSwitchPrefix?: string; // prefix for per-room switches
 }
 
 export interface MediaArtworkOverride {


### PR DESCRIPTION
## Summary
- extend `CardConfig` with AGS integration options
- document AGS options with example values

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68634376090083308c1904775cd8f1fe